### PR TITLE
feat: Implement playlist creation and improve auth

### DIFF
--- a/spotify-tags-ui/app/api/auth/*/[...nextauth]/route.ts
+++ b/spotify-tags-ui/app/api/auth/*/[...nextauth]/route.ts
@@ -1,11 +1,3 @@
-import { credentialsProvider, spotifyProvider } from "@/lib/nextauth";
-import NextAuth from "next-auth";
-
-const handler = NextAuth({
-  providers: [spotifyProvider, credentialsProvider],
-  pages: {
-    signIn: "/signin",
-  },
-  debug: true,
-});
-export { handler as GET, handler as POST };
+// for some wierd reasons, spotify does redirect to /api/auth/*/callback instead of /api/auth/callback
+// thus this route is added
+export { handler as GET, handler as POST } from "@/lib/nextauth/handler";

--- a/spotify-tags-ui/app/api/auth/[...nextauth]/route.ts
+++ b/spotify-tags-ui/app/api/auth/[...nextauth]/route.ts
@@ -1,11 +1,1 @@
-import { credentialsProvider, spotifyProvider } from "@/lib/nextauth";
-import NextAuth from "next-auth";
-
-const handler = NextAuth({
-  providers: [spotifyProvider, credentialsProvider],
-  pages: {
-    signIn: "/signin",
-  },
-  debug: true,
-});
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST } from "@/lib/nextauth/handler";

--- a/spotify-tags-ui/app/globals.css
+++ b/spotify-tags-ui/app/globals.css
@@ -20,6 +20,9 @@
   button {
     /* @apply duration-300; */
   }
+  button.btn {
+    @apply bg-white font-bold px-4 rounded-full text-black hover:opacity-70 duration-300;
+  }
 }
 
 @layer utilities {

--- a/spotify-tags-ui/app/page.tsx
+++ b/spotify-tags-ui/app/page.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable */
 "use client";
+import AuthWrapper from "@/components/AuthWrapper";
 import Header from "@/components/Header";
 import TrackList from "@/components/MainWrapper";
 import AudioPlayer from "@/components/player/AudioPlayer";
@@ -13,17 +14,19 @@ export default function Home() {
     <SessionProvider>
       <StoreProvider>
         <ModalsProvider>
-          <main>
-            <Header />
-            <div className="flex">
-              <div className="w-1/5">
-                <TagsFilters />
+          <AuthWrapper>
+            <main>
+              <Header />
+              <div className="flex">
+                <div className="w-1/5">
+                  <TagsFilters />
+                </div>
+                <div className="w-4/5">
+                  <TrackList isPreviewMode={false} />
+                </div>
               </div>
-              <div className="w-4/5">
-                <TrackList isPreviewMode={false} />
-              </div>
-            </div>
-          </main>
+            </main>
+          </AuthWrapper>
           <AudioPlayer />
         </ModalsProvider>
       </StoreProvider>

--- a/spotify-tags-ui/components/AuthWrapper.tsx
+++ b/spotify-tags-ui/components/AuthWrapper.tsx
@@ -1,0 +1,24 @@
+import { ExtendedSession } from "@/lib/nextauth/handler";
+import { useSession } from "next-auth/react";
+import React, { FC, PropsWithChildren, useEffect } from "react";
+
+const AuthWrapper: FC<PropsWithChildren> = ({ children }) => {
+  const { status, data } = useSession();
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      const token = (data as ExtendedSession).accessToken;
+      if (token) {
+        sessionStorage.setItem("token", token);
+      } else {
+        console.warn("missing access token from user session");
+      }
+    } else {
+      sessionStorage.removeItem("token");
+    }
+  }, [data, status]);
+
+  return <>{children}</>;
+};
+
+export default AuthWrapper;

--- a/spotify-tags-ui/components/MainWrapper.tsx
+++ b/spotify-tags-ui/components/MainWrapper.tsx
@@ -1,9 +1,16 @@
 "use client";
-import { Actions, loadAllTracksAction, useAppDispatch } from "@/lib/store";
+import {
+  Actions,
+  createPlaylistAction,
+  hasAnyTagSelectedSelector,
+  loadAllTracksAction,
+  useAppDispatch,
+} from "@/lib/store";
 import { SortBy, SortDirection } from "@/lib/types";
 import { FC, useEffect } from "react";
 import TracksTable from "./tracks/TracksTable";
 import TrackSearchInput from "./TrackSearchInput";
+import { useSelector } from "react-redux";
 
 type Props = {
   isPreviewMode: boolean;
@@ -11,6 +18,7 @@ type Props = {
 
 const TrackList: FC<Props> = ({ isPreviewMode }) => {
   const dispatcher = useAppDispatch();
+  const hasAnyTagsSelected = useSelector(hasAnyTagSelectedSelector);
 
   useEffect(() => {
     dispatcher(loadAllTracksAction(isPreviewMode));
@@ -20,6 +28,14 @@ const TrackList: FC<Props> = ({ isPreviewMode }) => {
     <div className="bg-zinc-900 p-4 md:m-4 rounded-md">
       <header className="flex items-center">
         <h1 className="text-white capitlize mb-4 mr-auto">Tracks</h1>
+        <button
+          className="btn"
+          title="create playlist with all filtered tracks"
+          onClick={() => dispatcher(createPlaylistAction("someting"))}
+          hidden={!hasAnyTagsSelected}
+        >
+          create playlist
+        </button>
         <TrackSearchInput className="mx-2" />
         <select
           name="sort"

--- a/spotify-tags-ui/components/SignOutFromSpotify.tsx
+++ b/spotify-tags-ui/components/SignOutFromSpotify.tsx
@@ -2,11 +2,12 @@ import { signOut } from "next-auth/react";
 import React from "react";
 
 const SignOutFromSpotify = () => {
+  const handleSignout = () => {
+    signOut({ callbackUrl: "/signin" });
+    sessionStorage.removeItem("token");
+  };
   return (
-    <button
-      className="bg-white font-bold px-4 rounded-full text-black hover:opacity-70 duration-300"
-      onClick={() => signOut({ callbackUrl: "/signin" })}
-    >
+    <button className="btn" onClick={handleSignout}>
       sign out
     </button>
   );

--- a/spotify-tags-ui/lib/api.ts
+++ b/spotify-tags-ui/lib/api.ts
@@ -1,10 +1,22 @@
 import axios from "axios";
 import { Track } from "./types";
 
+axios.interceptors.request.use(
+  (config) => {
+    const token = sessionStorage.getItem("token");
+    if (token != null) {
+      config.headers = { ...config.headers, "x-spotify-access-token": token };
+    }
+    console.warn("token is NOT set on sessionStorage");
+    return config;
+  },
+  (err) => Promise.reject(err),
+);
 export interface SpotifyAPI {
   fetchAllTracks: () => Promise<Array<Track>>;
   patchTrack: (trackId: string, tags: Array<string>) => Promise<Track>;
   deleteTrack: (trackId: string) => Promise<void>;
+  createPlaylist: (tracks: string[], tags: string[]) => Promise<unknown>;
 }
 
 export function createSpotifyAPI(): SpotifyAPI {
@@ -19,6 +31,10 @@ export function createSpotifyAPI(): SpotifyAPI {
     },
     deleteTrack: async (trackId) => {
       await axios.delete<void>("/api/tracks/" + trackId);
+    },
+    createPlaylist: async (tracks, tags) => {
+      const response = await axios.post<unknown>("/api/playlists", { tracks, tags });
+      return response.data;
     },
   };
 }

--- a/spotify-tags-ui/lib/nextauth/handler.ts
+++ b/spotify-tags-ui/lib/nextauth/handler.ts
@@ -1,0 +1,25 @@
+import { credentialsProvider, spotifyProvider } from "@/lib/nextauth/providers";
+import NextAuth, { Session } from "next-auth";
+import { JWT } from "next-auth/jwt";
+
+type CustomAuthProperties = { accessToken?: string };
+export type ExtendedSession = Session & CustomAuthProperties;
+export type ExtendedJWT = JWT & CustomAuthProperties;
+
+export const handler = NextAuth({
+  providers: [spotifyProvider, credentialsProvider],
+  pages: {
+    signIn: "/signin",
+  },
+  callbacks: {
+    async session(data) {
+      const newSession: ExtendedSession = { ...data.session, accessToken: (data.token as ExtendedJWT).accessToken };
+      return newSession;
+    },
+    async jwt({ token, account }) {
+      const extendedToken: ExtendedJWT = { ...token, accessToken: account?.access_token };
+      return extendedToken;
+    },
+  },
+  debug: true,
+});

--- a/spotify-tags-ui/lib/nextauth/providers.ts
+++ b/spotify-tags-ui/lib/nextauth/providers.ts
@@ -6,7 +6,7 @@ export const spotifyProvider = SpotifyProvider({
   clientSecret: process.env.SPOTIFY_CLIENT_SECRET!,
   authorization: {
     params: {
-      scope: "user-read-email user-read-currently-playing",
+      scope: "user-read-email user-read-currently-playing playlist-modify-private",
     },
   },
 });

--- a/spotify-tags-ui/lib/store.ts
+++ b/spotify-tags-ui/lib/store.ts
@@ -2,7 +2,7 @@ import { configureStore, createAction, createSelector, createSlice, PayloadActio
 import { useDispatch, useSelector } from "react-redux";
 import createSagaMiddleware from "redux-saga";
 import { allSagas } from "./sagas";
-import { Operator, SortBy, SortDirection, Track, TracksFilter } from "./types";
+import { Operator, SortBy, SortDirection, TagWrapper, Track, TracksFilter } from "./types";
 import {
   extractAndSortAllTags,
   filterAllTracks,
@@ -38,6 +38,7 @@ enum AppStatus {
 export const loadAllTracksAction = createAction<boolean>("api/tracks/load_all");
 export const deleteTrackAction = createAction<string>("api/tracks/delete");
 export const updateTrackTagsActions = createAction<string>("api/tracks/update_tags");
+export const createPlaylistAction = createAction<string>("api/playlists/create_private");
 
 const defaultFilters: TracksFilter = {
   tags: [],
@@ -166,3 +167,8 @@ export const modalTagsSelector = createSelector(
 );
 
 export const isPreviewModeSelector = (state: RootState) => state.previewMode;
+
+export const hasAnyTagSelectedSelector = createSelector(
+  [filterTagsSelector],
+  (tags: TagWrapper[]) => tags.some((tag) => tag.selected) ?? false,
+);

--- a/spotify-tags-ui/next.config.ts
+++ b/spotify-tags-ui/next.config.ts
@@ -12,6 +12,10 @@ const nextConfig: NextConfig = {
         source: "/api/tracks/:path",
         destination: `https://${process.env.NEXT_PUBLIC_API}/default/tracks/:path`,
       },
+      {
+        source: "/api/playlists",
+        destination: `https://${process.env.NEXT_PUBLIC_API}/default/playlists`,
+      },
     ];
   },
 };

--- a/spotify-tags/aws_lambda/client.py
+++ b/spotify-tags/aws_lambda/client.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import functools
+from http import HTTPStatus
+
+import spotipy
+from aws_lambda_powertools.event_handler import Response, content_types
+from spotipy import Spotify
+
+
+@functools.cache
+def get_client(access_token: str) -> Spotify:
+    return spotipy.Spotify(auth=access_token, auth_manager=None)
+
+
+def create_private_playlist(tags: set[str], tracks: set[str], access_token: str) -> dict:
+    client = get_client(access_token)
+    playlist = client.user_playlist_create(
+        user=client.current_user()['id'],
+        name='SpotifyTags#' + ' '.join(tags[:3]),
+        public=False,
+        collaborative=False,
+        description=' '.join(tags)
+    )
+    client.playlist_add_items(playlist['id'], tracks)
+    return playlist
+
+def handle_spotify_exception(e: spotipy.SpotifyException) -> Response:
+    if str(e.http_status).startswith('4'):
+        return Response(
+            status_code=e.http_status,
+            content_type=content_types.APPLICATION_JSON,
+            body={'error': e.msg }
+        )
+    else:
+        raise e

--- a/spotify-tags/events/tag.json
+++ b/spotify-tags/events/tag.json
@@ -75,7 +75,7 @@
        ]
     },
     "multiValueQueryStringParameters":"",
-    "path":"/label-track",
+    "path":"/playlists",
     "pathParameters":"",
     "queryStringParameters":"",
     "requestContext":{
@@ -96,7 +96,7 @@
           "userAgent":"Custom User Agent String",
           "userArn":""
        },
-       "path":"/label-track",
+       "path":"/playlists",
        "protocol":"HTTP/1.1",
        "requestId":"a3590457-cac2-4f10-8fc9-e47114bf7c62",
        "requestTime":"02/Feb/2023:11:45:26 +0000",
@@ -105,7 +105,7 @@
        "resourcePath":"/hello",
        "stage":"Prod"
     },
-    "resource":"/label-track",
+    "resource":"/playlists",
     "stageVariables":"",
     "version":"1.0"
  }

--- a/spotify-tags/oas.yaml
+++ b/spotify-tags/oas.yaml
@@ -110,9 +110,48 @@ paths:
                 type: string
                 example: 'SUCCESS'
                 default: 'SUCCESS'
-
+  /playlists:
+    post:
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: aws_proxy
+        uri: arn:aws:apigateway:eu-central-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-central-1:462555053910:function:spotify-tags-HelloWorldFunction-8gA0Ab0oyhlm/invocations
+        responses:
+          default:
+            statusCode: 200
+      summary: create private playlist
+      security:
+        - SpotifyAccessToken: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tags:
+                  type: array
+                  items:
+                    type: string
+                    example: 'abcderfg'
+                tracks:
+                  type: array
+                  items:
+                    type: string
+                    example: 'https://open.spotify.com/track/2KVb1qFVI8n9VuCucFS56k'
+      responses:
+        201:
+          description: playlist created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Playlist'
 
 components:
+  securitySchemes:
+    SpotifyAccessToken:
+      type: apiKey
+      in: header
+      name: x-spotify-access-token
   schemas:
     Track:
       type: object
@@ -137,3 +176,18 @@ components:
           items:
             type: string
             example: 'first second third'
+    Playlist:
+        type: object
+        required:
+          - id
+          - external_urls
+        properties:
+          description:
+            type: string
+          external_urls:
+            type: object
+            properties:
+              spotify:
+                  type: string
+          id:
+            type: string


### PR DESCRIPTION
This commit introduces functionality to create private Spotify playlists based on filtered tracks and selected tags.  Additionally, it refactors the authentication process for improved reliability and adds styling for buttons.  A bug causing incorrect Spotify redirect URLs is also fixed.
